### PR TITLE
Add building of transaction with test.

### DIFF
--- a/Sources/EngineToolkit/Models/Crypto.swift
+++ b/Sources/EngineToolkit/Models/Crypto.swift
@@ -297,6 +297,16 @@ public enum SignatureWithPublicKey: Sendable, Codable, Hashable {
     case ecdsaSecp256k1(EcdsaSecp256k1SignatureString)
     case eddsaEd25519(EddsaEd25519PublicKeyString, EddsaEd25519SignatureString)
 }
+public extension SignatureWithPublicKey {
+    var signature: Signature {
+        switch self {
+        case let .eddsaEd25519(_, signature):
+            return .eddsaEd25519(signature)
+        case let .ecdsaSecp256k1(signature):
+            return .ecdsaSecp256k1(signature)
+        }
+    }
+}
 
 private extension SignatureWithPublicKey {
    

--- a/Sources/EngineToolkit/Models/Transaction/Building.swift
+++ b/Sources/EngineToolkit/Models/Transaction/Building.swift
@@ -1,0 +1,102 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Cyon on 2022-10-10.
+//
+
+import Foundation
+
+public extension TransactionManifest {
+    func header(_ header: TransactionHeader) -> TransactionIntent {
+        .init(header: header, manifest: self)
+    }
+}
+
+public extension TransactionIntent {
+    func blobs(_ blobs: [[UInt8]]) -> Self {
+        .init(header: header, manifest: .init(instructions: self.manifest.instructions, blobs: blobs))
+    }
+}
+
+import CryptoKit
+public enum PrivateKey {
+    case curve25519(Curve25519.Signing.PrivateKey)
+}
+extension PrivateKey {
+    
+    func sign(data: any DataProtocol) throws -> SignatureWithPublicKey {
+        switch self {
+        case let .curve25519(key):
+            let signature = try key.signature(for: data)
+            let publicKey = key.publicKey
+            return .eddsaEd25519(
+                EddsaEd25519PublicKeyString(bytes: [UInt8](publicKey.rawRepresentation)),
+                EddsaEd25519SignatureString(bytes: [UInt8](signature))
+            )
+        }
+    }
+}
+
+public extension TransactionIntent {
+    func sign(with privateKey: Curve25519.Signing.PrivateKey) throws -> SignedTransactionIntent {
+        try sign(with: .curve25519(privateKey))
+    }
+    
+    func sign(with privateKey: PrivateKey) throws -> SignedTransactionIntent {
+        let compiledTransactionIntent = try EngineToolkit().compileTransactionIntentRequest(request: self).get().compiledIntent
+        let signature = try privateKey.sign(data: compiledTransactionIntent)
+        return SignedTransactionIntent(transactionIntent: self, signatures: [signature])
+    }
+}
+
+
+public extension SignedTransactionIntent {
+    func sign(with privateKey: Curve25519.Signing.PrivateKey) throws -> Self {
+        try sign(with: .curve25519(privateKey))
+    }
+    func sign(with privateKey: PrivateKey) throws -> Self {
+        
+        let signedTransactionIntent = SignedTransactionIntent(
+            transactionIntent: transactionIntent,
+            signatures: self.signatures
+        )
+        
+        
+        let compiledSignedTransactionIntent = try EngineToolkit().compileSignedTransactionIntentRequest(
+            request: signedTransactionIntent
+        ).get().compiledSignedIntent
+        
+        let signature = try privateKey.sign(data: compiledSignedTransactionIntent)
+        
+        return SignedTransactionIntent(
+            transactionIntent: transactionIntent,
+            signatures: signatures + [signature]
+        )
+    }
+}
+
+public extension SignedTransactionIntent {
+    func notarize(_ notaryPrivateKey: Curve25519.Signing.PrivateKey) throws -> NotarizedTransaction {
+        try notarize(.curve25519(notaryPrivateKey))
+    }
+    func notarize(_ notaryPrivateKey: PrivateKey) throws -> NotarizedTransaction {
+        
+        let signedTransactionIntent = SignedTransactionIntent(
+            transactionIntent: transactionIntent,
+            signatures: self.signatures
+        )
+        
+        let compiledSignedTransactionIntent = try EngineToolkit().compileSignedTransactionIntentRequest(
+            request: signedTransactionIntent
+        ).get().compiledSignedIntent
+        
+        // Notarize the signed intent to create a notarized transaction
+        let notarySignature = try notaryPrivateKey.sign(data: compiledSignedTransactionIntent)
+        
+        return NotarizedTransaction(
+            signedIntent: signedTransactionIntent,
+            notarySignature: notarySignature.signature
+        )
+    }
+}

--- a/Sources/EngineToolkit/Models/Transaction/NotarizedTransaction.swift
+++ b/Sources/EngineToolkit/Models/Transaction/NotarizedTransaction.swift
@@ -16,3 +16,4 @@ public struct NotarizedTransaction: Sendable, Codable, Hashable {
         case notarySignature = "notary_signature"
     }
 }
+

--- a/Sources/EngineToolkit/Models/Transaction/Transaction.swift
+++ b/Sources/EngineToolkit/Models/Transaction/Transaction.swift
@@ -74,9 +74,9 @@ extension TransactionManifest {
     init(@InstructionsBuilder buildInstructions: () throws -> [Instruction]) rethrows{
         try self.init(instructions: buildInstructions())
     }
- 
+    
     init(@SpecificInstructionsBuilder buildInstructions: () throws -> [any InstructionProtocol]) rethrows {
         try self.init(instructions: buildInstructions())
     }
- 
+    
 }

--- a/Sources/EngineToolkit/Models/Transaction/TransactionHeader.swift
+++ b/Sources/EngineToolkit/Models/Transaction/TransactionHeader.swift
@@ -14,7 +14,7 @@ public struct TransactionHeader: Sendable, Codable, Hashable {
     public let endEpochExclusive: UInt64
     public let nonce: UInt64
     public let publicKey: PublicKey
-    public let notaryAsSignature: Bool
+    public let notaryAsSignatory: Bool
     public let costUnitLimit: UInt32
     public let tipPercentage: UInt32
     
@@ -25,7 +25,7 @@ public struct TransactionHeader: Sendable, Codable, Hashable {
         case endEpochExclusive = "end_epoch_exclusive"
         case nonce = "nonce"
         case publicKey = "notary_public_key"
-        case notaryAsSignature = "notary_as_signatory"
+        case notaryAsSignatory = "notary_as_signatory"
         case costUnitLimit = "cost_unit_limit"
         case tipPercentage = "tip_percentage"
     }

--- a/Tests/EngineToolkitTests/Support/ExampleManifests/ExampleManifests.swift
+++ b/Tests/EngineToolkitTests/Support/ExampleManifests/ExampleManifests.swift
@@ -65,7 +65,7 @@ typealias TestTransaction = (
 // the EdDSA Ed25519 curve. 
 func testTransaction(
     signerCount: UInt,
-    notaryAsSigner: Bool = true
+    notaryAsSignatory: Bool = true
 ) throws -> TestTransaction {
     // The engine toolkit to use to create this notarized transaction
     let sut = EngineToolkit()
@@ -84,7 +84,7 @@ func testTransaction(
         publicKey: .eddsaEd25519(
             EddsaEd25519PublicKeyString(bytes: [UInt8](notaryPrivateKey.publicKey.rawRepresentation))
         ),
-        notaryAsSignature: notaryAsSigner,
+        notaryAsSignatory: notaryAsSignatory,
         costUnitLimit: 100_000_000,
         tipPercentage: 0
     )

--- a/Tests/EngineToolkitTests/TXInterfaceTests/TransactionBuildingTests.swift
+++ b/Tests/EngineToolkitTests/TXInterfaceTests/TransactionBuildingTests.swift
@@ -1,0 +1,72 @@
+@testable import EngineToolkit
+import CryptoKit
+
+extension Curve25519.Signing.PublicKey {
+    func isValidSignature(_ signatureWrapper: Signature, for message: any DataProtocol) -> Bool {
+        switch signatureWrapper {
+        case let .eddsaEd25519(signatureString):
+            let signatureData = Data(signatureString.bytes)
+            return isValidSignature(signatureData, for: message)
+        case .ecdsaSecp256k1: return false
+        }
+    }
+}
+
+final class TransactionBuildingTests: TestCase {
+    
+    func test_building_notarized_transaction() throws {
+
+        let privateKeyA = Curve25519.Signing.PrivateKey()
+        let privateKeyB = Curve25519.Signing.PrivateKey()
+        let privateKeyC = Curve25519.Signing.PrivateKey()
+        let notaryPrivateKey = Curve25519.Signing.PrivateKey()
+
+        let notarized = try TransactionManifest.complex
+            .header(.example(notaryPrivateKey: notaryPrivateKey))
+            .blobs([[0xde, 0xad], [0xbe, 0xef]])
+            .sign(with: privateKeyA)
+            .sign(with: privateKeyB)
+            .sign(with: privateKeyC)
+            .notarize(notaryPrivateKey)
+        
+        let signedTransactionIntent = SignedTransactionIntent(
+            transactionIntent: notarized.signedIntent.transactionIntent,
+            signatures: notarized.signedIntent.signatures
+        )
+        
+        let compiledSignedTransactionIntent = try EngineToolkit().compileSignedTransactionIntentRequest(
+            request: signedTransactionIntent
+        ).get().compiledSignedIntent
+        
+        let isValid = notaryPrivateKey
+            .publicKey
+            .isValidSignature(
+                notarized.notarySignature,
+                for: compiledSignedTransactionIntent
+            )
+        
+        XCTAssertTrue(isValid)
+    }
+}
+
+public extension TransactionHeader {
+    
+    static func example(
+        notaryPrivateKey: Curve25519.Signing.PrivateKey
+    ) -> Self {
+        
+        Self(
+            version: 0x01,
+            networkId: 0xF2,
+            startEpochInclusive: 0,
+            endEpochExclusive: 10,
+            nonce: 0,
+            publicKey: .eddsaEd25519(
+                EddsaEd25519PublicKeyString(bytes: [UInt8](notaryPrivateKey.publicKey.rawRepresentation))
+            ),
+            notaryAsSignatory: true,
+            costUnitLimit: 100_000_000,
+            tipPercentage: 0
+        )
+    }
+}


### PR DESCRIPTION
This PR add this syntax

```swift
let notarized = try TransactionManifest.complex
	.header(.example(notaryPrivateKey: notaryPrivateKey))
	.blobs([[0xde, 0xad], [0xbe, 0xef]])
	.sign(with: privateKeyA)
	.sign(with: privateKeyB)
	.sign(with: privateKeyC)
	.notarize(notaryPrivateKey)
```

Very similar to TransactionBuilder in Rust:

```rust
let transaction: NotarizedTransaction = TransactionBuilder()
    .manifest(transactionManifest)
    .header(transactionHeader)
    .blobs(blobs)
    .sign(signer1PrivateKey)
    .sign(signer2PrivateKey)
    .sign(signer3PrivateKey)
    .notarize(notaryPrivateKey)
    .build()
```

But the **Builder Pattern** is not so common in Swift. If we need something more powerful, we should use `@resultBuilder` and add more `buildBlock` methods, for e.g. adding of Blobs and signatures