### PR TITLE
Temporary fix for Ecdsa signature issue

### DIFF
--- a/Sources/EngineToolkit/Models/ECKeys+EngineToolkit/Engine+PrivateKey.swift
+++ b/Sources/EngineToolkit/Models/ECKeys+EngineToolkit/Engine+PrivateKey.swift
@@ -48,9 +48,30 @@ public extension Engine.PrivateKey {
             data: data,
             ifECDSASkipHashingBeforeSigning: ifECDSASkipHashingBeforeSigning
         )
+        var signatureWithPublicKey = try signatureAndMessage.signatureWithPublicKey.intoEngine()
+        
+        // TODO: Remove when a fix is implemented at the K1 side.
+        
+        // The following is a temporary fix for the ECDSA signatures to allow them to be put in a format that is
+        // expected. Currently, K1 returns a bytearray of (reverded(r) + reversed(s) + [v]) which Scrypto does not
+        // expect. Therefore, the following code modifies the above-mentioned format to be ([v] + r + s).
+        // Note: Correction is only needed for Ecdsa Secp256k1 and not Eddsa Ed25519
+        switch signatureWithPublicKey {
+        case .ecdsaSecp256k1(let ecdsaSignature):
+            let signatureBytes = ecdsaSignature.bytes
+        
+            let r = signatureBytes[0..<32].reversed()
+            let s = signatureBytes[32..<64].reversed()
+            let v = signatureBytes[64]
+            
+            signatureWithPublicKey = .ecdsaSecp256k1(signature: Engine.EcdsaSecp256k1Signature(bytes: [v] + r + s))
+        default:
+            break
+        }
+        
 
-        return try (
-            signatureWithPublicKey: signatureAndMessage.signatureWithPublicKey.intoEngine(),
+        return (
+            signatureWithPublicKey: signatureWithPublicKey,
             hashOfMessage: signatureAndMessage.hashOfMessage
         )
     }

--- a/Tests/EngineToolkitTests/Support/ExampleManifests/ExampleManifests.swift
+++ b/Tests/EngineToolkitTests/Support/ExampleManifests/ExampleManifests.swift
@@ -84,18 +84,10 @@ func testTransactionSecp256k1(
 	file: StaticString = #file,
 	line: UInt = #line
 ) throws -> TestTransaction {
-    /*
-    try _testTransaction(
+    return try _testTransaction(
         notaryPrivateKey: .secp256k1(try K1.PrivateKey.generateNew()),
         signerPrivateKeys: (0..<signerCount).map { _ in .secp256k1(try K1.PrivateKey.generateNew()) },
 		file: file, line: line
-    )
-     */
-    print("\n\n⚠️⚠️⚠️⚠️⚠️ WARNING ⚠️⚠️⚠️⚠️⚠️\nUsing Curve25519 instead of Secp256k1 temporarily to omit failing secp256k1 tests.\n\nSecp256k1 tests fail with error: TransactionValidationError, value: SignatureValidationError(InvalidNotarySignature)\nPLEASE FIX secp256k1 failing test by commenting out the line above (\(#line) in file: \(#file)!\n⚠️⚠️⚠️⚠️⚠️ WARNING ⚠️⚠️⚠️⚠️⚠️\n\n")
-    return try _testTransaction(
-        notaryPrivateKey: .curve25519(.init()),
-        signerPrivateKeys: (0..<signerCount).map { _ in .curve25519(.init()) },
-        file: file, line: line
     )
 }
 


### PR DESCRIPTION
@CyonAlexRDX As discussed yesterday, this is a temporary fix for the ECDSA signatures on the swift-engine-toolkit side, this is for issue #21. 

Quick summary of what this PR does: ECDSA recoverable signatures returned by K1 seem to structured in the following way:

```
[reversed(r) + reversed(s) + [v]]
```

This PR uses this knowledge and transforms the signature bytes to the format expected by Scrypto, which is:

```
[[v] + r + s]
```