### PR TITLE
Lower iOS required version to 11 (UNTESTED), what has been tested is …

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 
 let package = Package(
     name: "EngineToolkit",
-    platforms: [.macOS(.v12), .iOS(.v16)],
+    platforms: [.macOS(.v11), .iOS(.v11)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Tests/EngineToolkitTests/EngineToolkitTests.swift
+++ b/Tests/EngineToolkitTests/EngineToolkitTests.swift
@@ -1,8 +1,9 @@
-import EngineToolkitUniFFI
+import EngineToolkit
 import XCTest
 
 class EngineToolkitTests: XCTestCase {
-    func test_xz() {
-        assertionFailure()
+    func test_address_from_string() throws {
+        let address = try Address(address: "account_tdx_e_128vkt2fur65p4hqhulfv3h0cknrppwtjsstlttkfamj4jnnpm82gsw")
+        XCTAssertEqual(address.networkId(), 0x0e)
     }
 }


### PR DESCRIPTION
…iPhone simulator running iOS 14 on a M1 macOS 13.6 host